### PR TITLE
Adding ability to enforce with constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 */__pycache__
 *.egg-info
 *.pyc
+**/.idea

--- a/test/test_fn_16.py
+++ b/test/test_fn_16.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+from type_enforced import Enforcer
+from type_enforced.type import Constraint
+from type_enforced.exception import ConstraintError
+from typing import Annotated
+
+filename = Path(__file__).name
+
+PositiveInt = Annotated[int, Constraint(ge=0)]
+PositiveFloat = Annotated[float, Constraint(ge=0)]
+RunningStr = Annotated[str, Constraint(pattern=r".*running.*")]
+
+for i, curr_test in enumerate([
+    (PositiveInt, 0, True),
+    (PositiveInt, -1, ConstraintError),
+    (PositiveInt, "Hello There", TypeError),
+
+    (PositiveFloat, 0.1, True),
+    (PositiveFloat, -0.99, ConstraintError),
+    (PositiveFloat, "Hello There", TypeError),
+
+    (RunningStr, 0, TypeError),
+    (RunningStr, "this is a stopped status", ConstraintError),
+    (RunningStr, "this is running status", True),
+]):
+    hint, value, expected = curr_test
+    failure = False
+
+
+    @Enforcer
+    def func(value: hint):
+        return True
+    try:
+        response = func(value)
+        assert response == expected
+    except AssertionError:
+        failure = True
+    except Exception as err:
+        try:
+            assert isinstance(err, expected)
+        except AssertionError:
+            failure = True
+
+    msg = f"Test[{i}]"
+    if failure:
+        print(f"{msg}: {filename} failed")
+    else:
+        print(f"{msg}: {filename} passed")

--- a/type_enforced/exception.py
+++ b/type_enforced/exception.py
@@ -1,0 +1,2 @@
+class ConstraintError(Exception):
+    pass

--- a/type_enforced/type/__init__.py
+++ b/type_enforced/type/__init__.py
@@ -1,0 +1,3 @@
+from type_enforced.type.constraints import Constraint
+
+__all__ = ["Constraint"]

--- a/type_enforced/type/constraints.py
+++ b/type_enforced/type/constraints.py
@@ -1,0 +1,29 @@
+import re
+from type_enforced.exception import ConstraintError
+
+
+class __Constraint:
+    def __init__(self, **kwargs):
+        tmp = [(k, v) for k, v in kwargs.items() if v is not None]
+        _f = dict(
+            pattern=(lambda x, param: bool(re.findall(x, param)), "match pattern"),
+            gt=(lambda x, param: param > x, "be greater than"),
+            lt=(lambda x, param: param < x, "be less than"),
+            ge=(lambda x, param: param >= x, "be greater or equal to"),
+            le=(lambda x, param: param <= x, "be less than or equal to"),
+            eq=(lambda x, param: param == x, "be equal to"),
+            ne=(lambda x, param: param != x, "be not equal to"),
+        )
+        self.evaluate = [(*_f.get(k), k, v) for k, v in tmp if callable(_f.get(k)[0])]
+
+    def __call__(self, varname, value, param_type) -> bool:
+        for func, curr_msg, k, v in self.evaluate:
+            if not func(v, value):
+                reason = f"Expected {varname} to {curr_msg} '{v}' but got `{value}` instead."
+                msg = f"Constraint error for typed variable `{varname}` ({param_type}). {reason}"
+                raise ConstraintError(msg)
+        return True
+
+
+def Constraint(**kwargs):
+    return __Constraint(**kwargs)


### PR DESCRIPTION
This PR has enhances the Enforcer decorator to enforce parameters with constraints
Relates to Issue: https://github.com/connor-makowski/type_enforced/issues/36

## Examples:
```python
from type_enforced import Enforcer
from type_enforced.type import Constraint
from typing import Annotated

PositiveInt = Annotated[int, Constraint(ge=0)]


@Enforcer
def func(value: PositiveInt):
    return True


func(1)  # -> Valid
func(-1)  # Throws ConstraintError as per annotation we are expecting >= 0 (new behavior)
func("foo")  # Throws TypeError as annotation is set to integer (existing behavior)

```

```python
from type_enforced import Enforcer
from type_enforced.type import Constraint
from typing import Annotated

StoppedStrs = Annotated[str, Constraint(pattern=r".*stopped.*")]


@Enforcer
def func(value: StoppedStrs):
    return True


func("stopped instance")  # -> Valid
func("started instance")  # Throws ConstraintError as per annotation we are expecting strings to match pattern
func(1)  # Throws TypeError as annotation is set to integer

```
