### PR TITLE
Joss editorial edits

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -46,7 +46,7 @@
 
 @software{Loria:2013,
   author    = {Steven Loria},
-  title     = {Marshmallow},
+  title     = {{marshmallow}},
   version   = {4.0.0},
   year      = {2013},
   url       = {https://github.com/marshmallow-code/marshmallow},
@@ -56,7 +56,7 @@
 
 @inproceedings{Rak-amnouykit:2020,
 	location = {Virtual {USA}},
-	title = {Python 3 types in the wild: a tale of two type systems},
+	title = {{Python 3 Types in the Wild: A Tale of Two Type Systems}},
 	isbn = {978-1-4503-8175-8},
 	url = {https://dl.acm.org/doi/10.1145/3426422.3426981},
 	doi = {10.1145/3426422.3426981},
@@ -71,4 +71,24 @@
   year      = {2020},
 	date = {2020-11-17},
 	langid = {english},
+}
+
+@software{pyright:2025,
+  author    = {Microsoft Corporation},
+  title     = {Pyright},
+  version   = {1.1.405},
+  year      = {2025},
+  url       = {https://github.com/microsoft/pyright},
+  urldate   = {2025-09-21},
+  note      = {Static Type Checker for Python; GitHub repository}
+}
+
+@software{pytype:2025,
+  author    = {Google},
+  title     = {Pytype},
+  version   = {2024.10.11},
+  year      = {2024},
+  url       = {https://github.com/google/pytype},
+  urldate   = {2025-09-21},
+  note      = {A static type analyzer for Python code; GitHub repository}
 }

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -74,21 +74,21 @@
 }
 
 @software{pyright:2025,
-  author    = {Microsoft Corporation},
-  title     = {Pyright},
-  version   = {1.1.405},
-  year      = {2025},
-  url       = {https://github.com/microsoft/pyright},
-  urldate   = {2025-09-21},
-  note      = {Static Type Checker for Python; GitHub repository}
+	title        = {Pyright},
+	author       = {{Microsoft Corporation}},
+	year         = 2025,
+	url          = {https://github.com/microsoft/pyright},
+	urldate      = {2025-09-21},
+	note         = {Static Type Checker for Python; GitHub repository},
+	version      = {1.1.405}
 }
 
 @software{pytype:2025,
-  author    = {Google},
-  title     = {Pytype},
-  version   = {2024.10.11},
-  year      = {2024},
-  url       = {https://github.com/google/pytype},
-  urldate   = {2025-09-21},
-  note      = {A static type analyzer for Python code; GitHub repository}
+	title        = {Pytype},
+	author       = {Google},
+	year         = 2024,
+	url          = {https://github.com/google/pytype},
+	urldate      = {2025-09-21},
+	note         = {A static type analyzer for Python code; GitHub repository},
+	version      = {2024.10.11}
 }

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -65,9 +65,9 @@ Static type checkers analyze code before execution, using type hints to catch po
 
 - **Mypy** [@Lehtosalo:2012]: 
   Mypy is the most widely adopted static type checker for Python, implementing a conventional static type system based on PEP 484. It enforces fixed variable types and reports errors when type annotations are violated. As detailed by [@Rak-amnouykit:2020], Mypy represents the canonical approach to static type checking in Python, and its semantics have become a baseline for evaluating new type inference tools.
-- **Pyright** : 
+- **Pyright** [@pyright:2025]: 
   A fast type checker developed by Microsoft, offering real-time feedback in editors.
-- **PyType**: 
+- **PyType** [@pytype:2025]: 
   Developed by Google, PyType also provides static analysis and type inference for Python code, but with a distinct approach. Unlike Mypy, PyType maintains separate type environments for different branches in control flow and can infer more precise union types for variables that take on multiple types. The comparative study by [@Rak-amnouykit:2020] shows that PyType and Mypy differ in their handling of type joins, attribute typing, and error reporting, reflecting broader trade-offs in static analysis for dynamic languages.
 
 ## Runtime Type Checkers and Data Validation


### PR DESCRIPTION
I propose these two editorial edits:

1. Two minor  bibliography capitalization fixes, e.g., M &rarr; m in marshmallow.

2. Adding citations to pyright and pytype (without these citations, there is a whitespace issue at L68 of paper.md).

I have included both changes in the PR.

